### PR TITLE
Update github pages links and navigation

### DIFF
--- a/docs/assets/js/config.js
+++ b/docs/assets/js/config.js
@@ -7,34 +7,28 @@ const CONFIG = {
   // Site info
   siteTitle: 'k8s Cluster on Proxmox',
   
+  // Base path for GitHub Pages (set to '' for root domain)
+  basePath: '',
+  
   // Navigation structure
   navigation: [
     {
       title: 'はじめに',
       icon: 'fa-rocket',
       items: [
-        { title: '前準備', url: '/setup/prerequisites.html' },
-        { title: 'クラスター構築', url: '/setup/cluster-installation.html' }
+        { title: '前準備', url: 'setup/prerequisites.html' },
+        { title: 'クラスター構築', url: 'setup/cluster-installation.html' }
       ]
     },
     {
       title: 'コンポーネント',
       icon: 'fa-puzzle-piece',
       items: [
-        { title: 'ArgoCD', url: '/components/argocd.html' },
-        { title: 'Cloudflare Ingress', url: '/components/cloudflare-ingress.html' },
-        { title: 'Rook Ceph', url: '/components/rook-ceph.html' },
-        { title: 'Cert Manager', url: '/components/cert-manager.html' },
-        { title: 'Harbor', url: '/components/harbor.html' }
-      ]
-    },
-    {
-      title: 'オプション',
-      icon: 'fa-plus-circle',
-      items: [
-        { title: 'Firebolt Core', url: '/components/firebolt-core.html' },
-        { title: 'MinIO', url: '/components/minio.html' },
-        { title: 'Nginx Ingress', url: '/components/nginx-ingress.html' }
+        { title: 'ArgoCD', url: 'components/argocd.html' },
+        { title: 'Cloudflare Ingress', url: 'components/cloudflare-ingress.html' },
+        { title: 'Rook Ceph', url: 'components/rook-ceph.html' },
+        { title: 'Cert Manager', url: 'components/cert-manager.html' },
+        { title: 'Harbor', url: 'components/harbor.html' }
       ]
     }
   ],

--- a/docs/assets/js/navigation.js
+++ b/docs/assets/js/navigation.js
@@ -158,6 +158,26 @@
     },
     
     /**
+     * Get base path for navigation
+     */
+    getBasePath() {
+      const basePath = CONFIG.basePath || '';
+      const currentPath = window.location.pathname;
+      
+      // Determine depth from current location
+      const pathSegments = currentPath.split('/').filter(s => s && s !== 'index.html');
+      const depth = pathSegments.length;
+      
+      // If we're at root (docs/index.html), return basePath as is
+      if (depth === 0 || currentPath.endsWith('/docs/') || currentPath.endsWith('/docs/index.html')) {
+        return basePath;
+      }
+      
+      // For each level deep, add '../'
+      return '../'.repeat(depth) || './';
+    },
+    
+    /**
      * Render sidebar navigation
      */
     renderSidebar() {
@@ -167,6 +187,7 @@
       // Check if navigation is already rendered
       if (sidebar.querySelector('.nav-section')) return;
       
+      const basePath = this.getBasePath();
       let html = '';
       
       // Render navigation sections
@@ -181,9 +202,10 @@
         `;
         
         section.items.forEach(item => {
+          const url = basePath + item.url;
           html += `
               <li class="nav-item">
-                <a href="${item.url}" class="nav-link">${item.title}</a>
+                <a href="${url}" class="nav-link">${item.title}</a>
               </li>
           `;
         });

--- a/docs/index.html
+++ b/docs/index.html
@@ -24,7 +24,7 @@
   <!-- Header -->
   <header class="site-header">
     <div class="header-container">
-      <a href="/" class="logo">
+      <a href="./" class="logo">
         <i class="fas fa-cubes logo-icon"></i>
         <span class="logo-text">k8s Cluster</span>
       </a>
@@ -136,34 +136,6 @@
           </a>
         </div>
 
-        <!-- Optional Components -->
-        <h2 style="margin-top: var(--space-16);">➕ オプションコンポーネント</h2>
-        
-        <div class="component-grid">
-          <a href="components/firebolt-core.html" class="component-link">
-            <div class="component-link-title">
-              <i class="fas fa-fire"></i> Firebolt Core
-              <span class="badge badge-optional" style="margin-left: var(--space-2);">Optional</span>
-            </div>
-            <div class="component-link-desc">Firebolt データベース</div>
-          </a>
-          
-          <a href="components/minio.html" class="component-link">
-            <div class="component-link-title">
-              <i class="fas fa-cloud-upload-alt"></i> MinIO
-              <span class="badge badge-optional" style="margin-left: var(--space-2);">Optional</span>
-            </div>
-            <div class="component-link-desc">オブジェクトストレージ</div>
-          </a>
-          
-          <a href="components/nginx-ingress.html" class="component-link">
-            <div class="component-link-title">
-              <i class="fas fa-network-wired"></i> Nginx Ingress
-              <span class="badge badge-optional" style="margin-left: var(--space-2);">Optional</span>
-            </div>
-            <div class="component-link-desc">Nginx Ingress Controller</div>
-          </a>
-        </div>
 
         <!-- Version Info -->
         <h2 style="margin-top: var(--space-16);">🔧 バージョン情報</h2>


### PR DESCRIPTION
Remove unsupported components and fix navigation links to work correctly on GitHub Pages.

Navigation links were using absolute paths, leading to 404 errors when the site was hosted in a GitHub Pages sub-directory. This PR updates links to relative paths and dynamically calculates the correct base path to ensure navigation functions from any page depth.

---
<a href="https://cursor.com/background-agent?bcId=bc-6eedccd2-5a01-4ac5-b48b-59272d3f0a98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6eedccd2-5a01-4ac5-b48b-59272d3f0a98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

