### PR TITLE
Fix mobile sidebar close on github pages

### DIFF
--- a/docs/assets/js/navigation.js
+++ b/docs/assets/js/navigation.js
@@ -40,12 +40,20 @@
         this.toggleSidebar();
       });
 
-      // Close on overlay click
+      // Prevent sidebar clicks from closing
+      sidebar.addEventListener("click", (e) => {
+        e.stopPropagation();
+      });
+
+      // Close on overlay click and touch
       const currentOverlay = document.querySelector(".sidebar-overlay");
       if (currentOverlay) {
-        currentOverlay.addEventListener("click", () => {
+        const closeOnOverlay = () => {
           this.closeSidebar();
-        });
+        };
+        
+        currentOverlay.addEventListener("click", closeOnOverlay);
+        currentOverlay.addEventListener("touchend", closeOnOverlay);
       }
 
       // Close on link click (mobile)


### PR DESCRIPTION
Add `touchend` event listener to the sidebar overlay and prevent internal sidebar clicks to fix mobile sidebar closing issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-2bfd75ab-38f4-4f3b-a564-8f05164c84d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2bfd75ab-38f4-4f3b-a564-8f05164c84d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

